### PR TITLE
修复 RGSS3AFileError 抛出时参数个数错误，导致真实异常信息被 ArgumentError 掩盖

### DIFF
--- a/ext/R3EXS/R3EXS.cxx
+++ b/ext/R3EXS/R3EXS.cxx
@@ -303,8 +303,7 @@ VALUE r3exs_rgss3a_rvdata2(VALUE self, VALUE target_path, VALUE output_dir, VALU
         rb_exc_raise(rb_funcall(
             rb_const_get(self, rb_intern("RGSS3AFileError")),
             rb_intern("new"),
-            2,
-            target_path,
+            1,
             rb_str_new_cstr(e.what())
         ));
     }


### PR DESCRIPTION
## 问题

`ext/R3EXS/R3EXS.cxx` 中 `r3exs_rgss3a_rvdata2` 的 catch 分支以 **2 个参数**（`target_path` 和错误消息）调用 `R3EXS::RGSS3AFileError.new`：

```cpp
catch (const RGSS3AFileError& e)
{
    rb_exc_raise(rb_funcall(
        rb_const_get(self, rb_intern("RGSS3AFileError")),
        rb_intern("new"),
        2,
        target_path,
        rb_str_new_cstr(e.what())
    ));
}
```

但 `RGSS3AFileError` 继承自 `StandardError`，构造器只接受 0..1 个参数。因此**任何**触发 `RGSS3AFileError` 的场景，实际抛出的都是：

```
ArgumentError: wrong number of arguments (given 2, expected 0..1)
```

原本的错误原因（`Unknown RGSS3A file decrypted type:...`，消息中已包含档案路径）被完全掩盖，对使用者排障有误导性。

## 复现步骤

```bash
# 构造一个非法格式的假档案
ruby -e 'File.binwrite("fake.rgss3a", "GARBAGE" * 8)'
R3EXS decrypt ./fake.rgss3a
```

修复前的输出（CLI 的 on_error 捕获后仅打印）：

```
wrong number of arguments (given 2, expected 0..1)
```

完全看不出是"档案格式不支持"。

## 修复方式

只传入 1 个参数（错误消息）。消息本身由 `std::format("Unknown RGSS3A file decrypted type:{}", target_path.string())` 生成，已包含路径，去掉第二个参数后无任何信息丢失：

```cpp
catch (const RGSS3AFileError& e)
{
    rb_exc_raise(rb_funcall(
        rb_const_get(self, rb_intern("RGSS3AFileError")),
        rb_intern("new"),
        1,
        rb_str_new_cstr(e.what())
    ));
}
```

## 修复后效果

```
R3EXS::RGSS3AFileError: Unknown RGSS3A file decrypted type:fake.rgss3a
```

## 验证

已在 Windows（Ruby 4.0.2 x64-mingw-ucrt / gcc 16.1.0）上完成：

1. 修改后 C 扩展编译、链接通过；
2. `decrypt` 非法格式档案抛出 `R3EXS::RGSS3AFileError` 且消息正确；
3. 正常功能不受影响（`decrypt` 正常档案、`rvdata2_json`、`ex_strings`、`in_strings`、`json_rvdata2` 全流程回归通过）。

谢谢！